### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 ADD target/mqtt-frontend-1.0-SNAPSHOT.jar /
 


### PR DESCRIPTION
@ppatierno This reduces the docker image size from 136MB to 53MB (see https://hub.docker.com/r/enmasseproject/mqtt-frontend/tags/ vs https://hub.docker.com/r/lulf/mqtt-frontend/tags/)